### PR TITLE
feat: WorktreeCreate hook で worktree 環境を自動セットアップ

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true
+  },
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "input=$(cat); name=$(echo \"$input\" | jq -r '.name'); cwd=$(echo \"$input\" | jq -r '.cwd'); bash \"$cwd/scripts/worktree-setup.sh\" create \"$name\" 1>&2; echo \"$cwd/worktrees/$name\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -199,7 +199,7 @@ SUBCOMMAND="${1:-setup}"
 
 case "${SUBCOMMAND}" in
   setup)
-    run_setup "${REPO_ROOT}"
+    run_setup "${2:-${REPO_ROOT}}"
     ;;
   create)
     cmd_create "${2:-}"


### PR DESCRIPTION
## Summary

- `claude --worktree <name>` 実行時に `WorktreeCreate` hook が自動発火
- `scripts/worktree-setup.sh create <name>` を呼び出し、git worktree 作成 + Docker 起動 + migration まで自動化
- `setup` サブコマンドにオプションの `dir` 引数を追加（hook から worktree ディレクトリを指定可能に）

## 動作

```
claude --worktree <name>
```

↓ WorktreeCreate hook 発火

↓ `scripts/worktree-setup.sh create <name>` 実行（stderr に出力）

↓ worktree パスを stdout に出力 → Claude が起動

## Test plan

- [ ] `claude --worktree <name>` で新規 worktree が作成され Claude が起動することを確認
- [ ] `worktrees/<name>/` に Docker コンテナ・DB・migration が完了した状態になることを確認
- [ ] `scripts/worktree-setup.sh cleanup <name>` で手動クリーンアップできることを確認